### PR TITLE
Add codemod to remove unnecessary assignment of context types in init…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cjsx2jsx",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Convert CJSX files to modern JSX",
   "main": "lib/index.js",
   "scripts": {

--- a/src/codemod/remove-redundant-context-types.js
+++ b/src/codemod/remove-redundant-context-types.js
@@ -1,5 +1,9 @@
 export default function transformer(file, api) {
   const j = api.jscodeshift;
+
+  const removeNodeAtPath = path => {
+    j(path).replaceWith();
+  };
   
   const classPropertyCopiedFromAssignment = (propertyName, copiedFrom) => ({
     type: "AssignmentExpression",
@@ -20,10 +24,6 @@ export default function transformer(file, api) {
     .filter(path => path.node.superClass)
     .forEach(path => {
       const superClass = path.node.superClass.name;
-    
-      const removeNodeAtPath = path => {
-        j(path).replaceWith();
-      };
     
       const initClass = j(path).find(j.MethodDefinition, {
         static: true,

--- a/src/codemod/remove-redundant-context-types.js
+++ b/src/codemod/remove-redundant-context-types.js
@@ -1,0 +1,45 @@
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  
+  const classPropertyCopiedFromAssignment = (propertyName, copiedFrom) => ({
+    type: "AssignmentExpression",
+    operator: '=', 
+    left: {
+      type: "MemberExpression",
+      object: { type: "ThisExpression" },
+      property: { type: "Identifier", name: propertyName }
+    },
+    right: {
+      type: "MemberExpression",
+      object: { type: "Identifier", name: copiedFrom },
+      property: { type: "Identifier", name: propertyName }
+    }
+  });
+  
+  return j(file.source).find(j.ClassDeclaration)
+    .filter(path => path.node.superClass)
+    .forEach(path => {
+      const superClass = path.node.superClass.name;
+    
+      const removeNodeAtPath = path => {
+        j(path).replaceWith();
+      };
+    
+      const initClass = j(path).find(j.MethodDefinition, {
+        static: true,
+        key: { name: 'initClass' }
+      });
+    
+      initClass.find(j.ExpressionStatement, {
+        expression: classPropertyCopiedFromAssignment('contextTypes', superClass)
+      })
+      .forEach(removeNodeAtPath);
+
+      initClass.find(j.ExpressionStatement, {
+        expression: classPropertyCopiedFromAssignment('childContextTypes', superClass)
+      })
+      .forEach(removeNodeAtPath);
+      
+    })
+    .toSource();
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import coffeeReactTransform from 'coffee-react-transform';
 import { convert } from 'decaffeinate';
 import { transform } from 'babel-core';
+import removeRedundantContextTypes from './codemod/remove-redundant-context-types';
 import createElementTransform from 'babel-plugin-transform-react-createelement-to-jsx';
 import jscodeshift from 'jscodeshift';
 import fs from 'fs';
@@ -27,6 +28,12 @@ export function run(args) {
   const bindToArrowSource = bindToArrowTransform( {source: source}, {jscodeshift: jscodeshift});
   if (bindToArrowSource) {
     source = bindToArrowSource;
+  }
+
+  // Returns null if there was nothing to transform
+  const removeRedundantContextTypesSource = removeRedundantContextTypes( {source: source}, {jscodeshift: jscodeshift});
+  if (removeRedundantContextTypesSource ) {
+    source = removeRedundantContextTypesSource; 
   }
   console.log(source);
 }


### PR DESCRIPTION
…Class

The intent here is to cleanup initClass artifacts that look like this:
```
class AccountEdit extends EditModelRoute {
  static initClass() {
    this.contextTypes = EditModelRoute.contextTypes;
    this.childContextTypes = EditModelRoute.childContextTypes;
    this.className = 'account-edit-component';
    this.prototype.typeKey = 'account';

    this.prototype.hasBreadcrumb = true;
  }
```

by removing the two contextTypes lines.  These are coffeescript artifacts.